### PR TITLE
AllRightsReserved => Apache-2.0

### DIFF
--- a/docker2nix/Main.hs
+++ b/docker2nix/Main.hs
@@ -14,7 +14,7 @@
 -- |
 -- Module      :  docker2nix/Main
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/hocker-config/Main.hs
+++ b/hocker-config/Main.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  hocker-config/Main
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/hocker-image/Main.hs
+++ b/hocker-image/Main.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  hocker-fetch/Main
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/hocker-layer/Main.hs
+++ b/hocker-layer/Main.hs
@@ -14,7 +14,7 @@
 -- |
 -- Module      :  hocker-layer/Main
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/hocker-manifest/Main.hs
+++ b/hocker-manifest/Main.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  hocker-manifest/Main
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Data/Docker/Image/AesonHelpers.hs
+++ b/src/Data/Docker/Image/AesonHelpers.hs
@@ -2,7 +2,7 @@
 -- |
 -- Module      :  Data.Docker.Image.AesonHelpers
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Data/Docker/Image/Types.hs
+++ b/src/Data/Docker/Image/Types.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Data.Docker.Image.Types
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Data/Docker/Image/V1/Layer.hs
+++ b/src/Data/Docker/Image/V1/Layer.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Data.Docker.Image.V1.Layer
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 --

--- a/src/Data/Docker/Image/V1/Types.hs
+++ b/src/Data/Docker/Image/V1/Types.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Data.Docker.Image.V1.Types
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Data/Docker/Image/V1_2/Types.hs
+++ b/src/Data/Docker/Image/V1_2/Types.hs
@@ -9,7 +9,7 @@
 -- |
 -- Module      :  Data.Docker.Image.V1_2.Types
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 --

--- a/src/Data/Docker/Nix.hs
+++ b/src/Data/Docker/Nix.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Data.Docker.Nix
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 --

--- a/src/Data/Docker/Nix/FetchDocker.hs
+++ b/src/Data/Docker/Nix/FetchDocker.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  Data.Docker.Nix.FetchDocker
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Data/Docker/Nix/Lib.hs
+++ b/src/Data/Docker/Nix/Lib.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  Data.Docker.Nix.Lib
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -10,7 +10,7 @@
 -- |
 -- Module      :  Lib
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Network/Wreq/Docker/Image/Lib.hs
+++ b/src/Network/Wreq/Docker/Image/Lib.hs
@@ -8,7 +8,7 @@
 -- |
 -- Module      :  Network.Wreq.Docker.Image.Lib
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Network/Wreq/Docker/Image/V1_2.hs
+++ b/src/Network/Wreq/Docker/Image/V1_2.hs
@@ -9,7 +9,7 @@
 -- |
 -- Module      :  Network.Wreq.Docker.Image.V1_2
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Network/Wreq/Docker/Registry/V2.hs
+++ b/src/Network/Wreq/Docker/Registry/V2.hs
@@ -11,7 +11,7 @@
 -- |
 -- Module      :  Network.Wreq.Docker.Registry.V2
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 --

--- a/src/Network/Wreq/ErrorHandling.hs
+++ b/src/Network/Wreq/ErrorHandling.hs
@@ -10,7 +10,7 @@
 -- |
 -- Module      :  Network.Wreq.ErrorHandling
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -15,7 +15,7 @@
 -- |
 -- Module      :  Types
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Types/Exceptions.hs
+++ b/src/Types/Exceptions.hs
@@ -10,7 +10,7 @@
 -- |
 -- Module      :  Types.Exceptions
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Types/Hash.hs
+++ b/src/Types/Hash.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Types.Hash
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Types/ImageName.hs
+++ b/src/Types/ImageName.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Types.ImageName
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Types/ImageTag.hs
+++ b/src/Types/ImageTag.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Types.ImageTag
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/src/Types/URI.hs
+++ b/src/Types/URI.hs
@@ -7,7 +7,7 @@
 -- |
 -- Module      :  Types.URI
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/test/Tests/Data/Docker/Image/V1.hs
+++ b/test/Tests/Data/Docker/Image/V1.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Data.Docker.Image.V1
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/test/Tests/Data/Docker/Image/V1_2.hs
+++ b/test/Tests/Data/Docker/Image/V1_2.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Data.Docker.Image.V1_2
 -- Copyright   :  (C) 2016 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------

--- a/test/Tests/Data/Docker/Nix/FetchDocker.hs
+++ b/test/Tests/Data/Docker/Nix/FetchDocker.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module      :  Data.Docker.Nix.FetchDocker
 -- Copyright   :  (C) 2017 Awake Networks
--- License     :  AllRightsReserved
+-- License     :  Apache-2.0
 -- Maintainer  :  Awake Networks <opensource@awakenetworks.com>
 -- Stability   :  stable
 ----------------------------------------------------------------------------


### PR DESCRIPTION
This change fixes each source file comment header's license field to match the Apache 2.0 license we have specified in `LICENSE` and in `hocker.cabal`.