### PR TITLE
Small cosmetic tweaks

### DIFF
--- a/hocker-config/Main.hs
+++ b/hocker-config/Main.hs
@@ -28,7 +28,7 @@ progSummary :: Data.Text.Text
 progSummary = "Fetch a docker image config JSON from the registry"
 
 main :: IO ()
-main = unwrapRecord progSummary >>= \OptArgs{..} -> do
+main = unwrapRecord progSummary >>= \Options{..} -> do
   let dockerRegistry = fromMaybe defaultRegistry registry
 
   auth   <- mkAuth dockerRegistry imageName credentials

--- a/hocker-image/Main.hs
+++ b/hocker-image/Main.hs
@@ -30,7 +30,7 @@ progSummary :: Data.Text.Text
 progSummary = "Fetch a docker image from a docker registry without using docker"
 
 main :: IO ()
-main = unwrapRecord progSummary >>= \OptArgs{..} -> do
+main = unwrapRecord progSummary >>= \Options{..} -> do
   let dockerRegistry = fromMaybe defaultRegistry registry
 
   auth <- mkAuth dockerRegistry imageName credentials

--- a/hocker-layer/Main.hs
+++ b/hocker-layer/Main.hs
@@ -45,7 +45,7 @@ data ProgArgs w = ProgArgs
       <?> "Write content to location"
       -- | Layer sha256 hash digest to fetch from registry
     , imageLayer  :: w ::: Hash.Digest Hash.SHA256
-      <?> "Layer to fetch, by hash digest (unprefixed by the hash algorithm identifier)"
+      <?> "Hash digest of layer to fetch"
       -- | Docker image name (includes the repository, e.g: library/debian)
     , imageName   :: ImageName
       -- | Docker image tag

--- a/hocker-manifest/Main.hs
+++ b/hocker-manifest/Main.hs
@@ -28,7 +28,7 @@ progSummary :: Data.Text.Text
 progSummary = "Pull a docker image manifest from the registry"
 
 main :: IO ()
-main = unwrapRecord progSummary >>= \OptArgs{..} -> do
+main = unwrapRecord progSummary >>= \Options{..} -> do
   let dockerRegistry =  fromMaybe defaultRegistry registry
 
   auth     <- mkAuth dockerRegistry imageName credentials

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -32,7 +32,7 @@ import           Data.Coerce
 import           Data.Monoid
 import qualified Data.Text                    as T
 import           Data.Text.Encoding           (encodeUtf8)
-import           Network.Wreq
+import qualified Network.Wreq                 as Wreq
 import           Nix.Expr                     (NExpr)
 import           Nix.Pretty
 import           System.Directory             (findExecutable)
@@ -101,9 +101,9 @@ joinURIPath pts uri@URI{..} = uri { uriPath = joinedParts }
   where
     joinedParts = C8.pack $ File.joinPath ("/":"v2":(C8.unpack uriPath):pts)
 
--- | Produce an @Options@ using @Network.Wreq.defaults@ and an @Auth@.
-opts :: Maybe Auth -> Options
-opts bAuth = Network.Wreq.defaults & Network.Wreq.auth .~ bAuth
+-- | Produce an @Wreq.Options@ using @Network.Wreq.defaults@ and an @Auth@.
+opts :: Maybe Wreq.Auth -> Wreq.Options
+opts bAuth = Wreq.defaults & Wreq.auth .~ bAuth
 
 -- | Hash a @Data.ByteString.Lazy.Char8@ using the SHA256 algorithm.
 sha256 :: C8L.ByteString -> Hash.Digest Hash.SHA256

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -33,7 +33,6 @@ import qualified Data.ByteString.Lazy
 import           Data.Monoid
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
-import           Network.Wreq
 import qualified Network.Wreq               as Wreq
 import           Network.Wreq.ErrorHandling
 import qualified Options.Applicative        as Options
@@ -69,18 +68,18 @@ type Manifest        = Data.ByteString.Lazy.ByteString
 type ImageConfigJSON = Data.ByteString.Lazy.ByteString
 
 -- | Wreq response type parameterized by the lazy bytestring type.
-type RspBS          = Network.Wreq.Response Data.ByteString.Lazy.ByteString
+type RspBS           = Wreq.Response Data.ByteString.Lazy.ByteString
 
 -- | A file extension.
 type Extension       = String
 
 -- | RepoName is the part before the forward slash in a docker image
 -- name, e.g: @library@ in @library/debian@
-type RepoNamePart  = Text
+type RepoNamePart    = Text
 
 -- | ImageName is the part after the forward slash in a docker image
 -- name, e.g: @library@ in @library/debian@
-type ImageNamePart = Text
+type ImageNamePart   = Text
 
 -- | Docker image config JSON file's sha256 hash digest in Nix's
 -- base32 encoding.
@@ -88,29 +87,29 @@ type ImageNamePart = Text
 -- NB: it's very important to realize there's a significant difference
 -- between Nix's base32 encoding and the standard base32 encoding!
 -- (i.e, they're not compatible).
-type ConfigDigest = Base32Digest
+type ConfigDigest    = Base32Digest
 
 -- | Generic top-level optparse-generic CLI args data type and
 -- specification.
 --
 -- NOTE: `hocker-layer` does not use this data type because it
 -- requires an additional layer sha256 hash digest argument.
-data OptArgs w = OptArgs
+data Options w = Options
     { -- | URI for the registry, optional
-      registry :: w ::: Maybe RegistryURI
+      registry    :: w ::: Maybe RegistryURI
       <?> "URI of registry, defaults to the Docker Hub registry"
     , credentials :: Maybe Credentials
       -- | Filesystem path to write output to
-    , out      :: w ::: Maybe FilePath
+    , out         :: w ::: Maybe FilePath
       <?> "Write content to location"
       -- | Docker image name (includes the reponame, e.g: library/debian)
-    , imageName     :: ImageName
+    , imageName   :: ImageName
       -- | Docker image tag
-    , imageTag      :: ImageTag
+    , imageTag    :: ImageTag
     } deriving (Generic)
 
-instance ParseRecord (OptArgs Wrapped)
-deriving instance Show (OptArgs Unwrapped)
+instance ParseRecord (Options Wrapped)
+deriving instance Show (Options Unwrapped)
 
 -- | Hocker 'ExceptT' and 'ReaderT' transformer stack threading a
 -- 'HockerMeta' data type.


### PR DESCRIPTION
This change updates the name of the data type we use to derive option parsers, updates a few locations where `Wreq` wasn't being qualified and its own `Option` data type clashed with the new name. I also tweaked the top-level README for minor language goofiness.