### PR TITLE
Fixing docker2nix's Nix expression output

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,26 +62,25 @@ Next, we can easily generate a `fetchdocker` derivation using `docker2nix`:
 
 ```shell
 $ hocker-manifest library/debian jessie | docker2nix library/debian jessie
-{
-  config.docker.images.debian = pkgs.fetchdocker {
+{ fetchDockerConfig, fetchDockerLayer, fetchdocker }:
+fetchdocker {
     name = "debian";
     registry = "https://registry-1.docker.io/v2/";
     repository = "library";
     imageName = "debian";
     tag = "jessie";
-    imageConfig = pkgs.fetchDockerConfig {
+    imageConfig = fetchDockerConfig {
       inherit registry repository imageName tag;
-      sha256 = "1viqbygsz9547jy830f2lk2hcrxjf7gl9h1xda9ws5kap8yw50ry";
+      sha256 = "1rwinmvfc8jxn54y7qnj82acrc97y7xcnn22zaz67y76n4wbwjh5";
     };
     imageLayers = let
-      layer0 = pkgs.fetchDockerLayer {
+      layer0 = fetchDockerLayer {
         inherit registry repository imageName tag;
-        layerDigest = "10a267c67f423630f3afe5e04bbbc93d578861ddcc54283526222f3ad5e895b9";
-        sha256 = "1fcmx3aklbr24qsjhm6cvmhqhmrxr6xlpq75mzrk0dj2gz36g8hh";
+        layerDigest = "cd0a524342efac6edff500c17e625735bbe479c926439b263bbe3c8518a0849c";
+        sha256 = "1744l0c8ag5y7ck9nhr6r5wy9frmaxi7xh80ypgnxb7g891m42nd";
       };
       in [ layer0 ];
-  };
-}
+  }
 ```
 
 ## Private Registries

--- a/docker2nix/README.md
+++ b/docker2nix/README.md
@@ -30,26 +30,25 @@ JSON retrieved by `hocker-manifest`:
 
 ```shell
 $ hocker-manifest library/debian jessie | docker2nix library/debian jessie
-{
-  config.docker.images.debian = pkgs.fetchdocker {
+{ fetchDockerConfig, fetchDockerLayer, fetchdocker }:
+fetchdocker {
     name = "debian";
     registry = "https://registry-1.docker.io/v2/";
     repository = "library";
     imageName = "debian";
     tag = "jessie";
-    imageConfig = pkgs.fetchDockerConfig {
+    imageConfig = fetchDockerConfig {
       inherit registry repository imageName tag;
       sha256 = "1rwinmvfc8jxn54y7qnj82acrc97y7xcnn22zaz67y76n4wbwjh5";
     };
     imageLayers = let
-      layer0 = pkgs.fetchDockerLayer {
+      layer0 = fetchDockerLayer {
         inherit registry repository imageName tag;
         layerDigest = "cd0a524342efac6edff500c17e625735bbe479c926439b263bbe3c8518a0849c";
         sha256 = "1744l0c8ag5y7ck9nhr6r5wy9frmaxi7xh80ypgnxb7g891m42nd";
       };
       in [ layer0 ];
-  };
-}
+  }
 ```
 
 And to load a fetched docker image into a running docker daemon on a NixOS

--- a/test/data/golden-debian:jessie.nix
+++ b/test/data/golden-debian:jessie.nix
@@ -1,20 +1,19 @@
-{
-  config.docker.images.debian = pkgs.fetchdocker {
+{ fetchDockerConfig, fetchDockerLayer, fetchdocker }:
+fetchdocker {
     name = "debian";
     registry = "https://registry-1.docker.io/v2/";
     repository = "library";
     imageName = "debian";
     tag = "jessie";
-    imageConfig = pkgs.fetchDockerConfig {
+    imageConfig = fetchDockerConfig {
       inherit registry repository imageName tag;
       sha256 = "1rwinmvfc8jxn54y7qnj82acrc97y7xcnn22zaz67y76n4wbwjh5";
     };
     imageLayers = let
-      layer0 = pkgs.fetchDockerLayer {
+      layer0 = fetchDockerLayer {
         inherit registry repository imageName tag;
         layerDigest = "cd0a524342efac6edff500c17e625735bbe479c926439b263bbe3c8518a0849c";
         sha256 = "1744l0c8ag5y7ck9nhr6r5wy9frmaxi7xh80ypgnxb7g891m42nd";
       };
       in [ layer0 ];
-  };
-}
+  }


### PR DESCRIPTION
Prior to this change `docker2nix` did not behave similarly to `cabal2nix` or other `*2nix` utilities. Namely it did not produce isolated and specific derivations, it produced a NixOS module-looking expression.

Outputting a NixOS module-looking expression is not technically wrong, it was simply going to complicate usage and it also made it more difficult to produce discrete `nix-build`-able expressions.

This change updates the output of `docker2nix` so that it can be called with `pkgs.callPackage` easily (assuming the `fetchdocker*` set of derivation wrappers are available on the system.)