### PR TITLE
Fixing the output of docker2nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,19 +63,19 @@ Next, we can easily generate a `fetchdocker` derivation using `docker2nix`:
 ```shell
 $ hocker-manifest library/debian jessie | docker2nix library/debian jessie
 { fetchDockerConfig, fetchDockerLayer, fetchdocker }:
-fetchdocker {
+fetchdocker rec {
     name = "debian";
     registry = "https://registry-1.docker.io/v2/";
     repository = "library";
     imageName = "debian";
     tag = "jessie";
     imageConfig = fetchDockerConfig {
-      inherit registry repository imageName tag;
+      inherit tag registry repository imageName;
       sha256 = "1rwinmvfc8jxn54y7qnj82acrc97y7xcnn22zaz67y76n4wbwjh5";
     };
     imageLayers = let
       layer0 = fetchDockerLayer {
-        inherit registry repository imageName tag;
+        inherit registry repository imageName;
         layerDigest = "cd0a524342efac6edff500c17e625735bbe479c926439b263bbe3c8518a0849c";
         sha256 = "1744l0c8ag5y7ck9nhr6r5wy9frmaxi7xh80ypgnxb7g891m42nd";
       };

--- a/src/Lib.hs
+++ b/src/Lib.hs
@@ -39,9 +39,8 @@ import           System.Directory             (findExecutable)
 import           System.Environment           (getProgName)
 import           System.Exit                  as Exit
 import           System.FilePath.Posix        as File
-import           System.IO                    (stdout)
 import           Text.PrettyPrint.ANSI.Leijen as Text.PrettyPrint (SimpleDoc,
-                                                                   displayIO,
+                                                                   displayS,
                                                                    renderPretty)
 import           URI.ByteString
 
@@ -174,7 +173,7 @@ renderNixExpr = renderPretty 0.4 120 . prettyNix
 
 -- | Pretty print a Nix expression AST and print to stdout.
 pprintNixExpr :: NExpr -> IO ()
-pprintNixExpr = displayIO stdout . renderNixExpr
+pprintNixExpr expr = Prelude.putStrLn (displayS (renderNixExpr expr) "")
 
 -- | Given an executable's name, try to find it in the current
 -- process's PATH context.

--- a/test/data/golden-debian:jessie.nix
+++ b/test/data/golden-debian:jessie.nix
@@ -1,17 +1,17 @@
 { fetchDockerConfig, fetchDockerLayer, fetchdocker }:
-fetchdocker {
+fetchdocker rec {
     name = "debian";
     registry = "https://registry-1.docker.io/v2/";
     repository = "library";
     imageName = "debian";
     tag = "jessie";
     imageConfig = fetchDockerConfig {
-      inherit registry repository imageName tag;
+      inherit tag registry repository imageName;
       sha256 = "1rwinmvfc8jxn54y7qnj82acrc97y7xcnn22zaz67y76n4wbwjh5";
     };
     imageLayers = let
       layer0 = fetchDockerLayer {
-        inherit registry repository imageName tag;
+        inherit registry repository imageName;
         layerDigest = "cd0a524342efac6edff500c17e625735bbe479c926439b263bbe3c8518a0849c";
         sha256 = "1744l0c8ag5y7ck9nhr6r5wy9frmaxi7xh80ypgnxb7g891m42nd";
       };


### PR DESCRIPTION
- fetchdocker's function argument set needed to be a recursive set in
  order for inherits to work correctly
- fetchDockerLayers does not take a tag argument, so only inherit the
  registry, repository, and imageName attributes

The reason for this change arose from functionally testing the improved `fetchdocker` derivations in anticipation of submitting a pull request to `nixpkgs` to add them (and `hocker`).